### PR TITLE
Add PHPUnit tests and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 
 JVPDF is a wrapper around TCPDF and FPDI to create cleaner code for fairly simple PDF file generation.
 Take a look at the examples for usage.
+
+## Running Tests
+
+Install dependencies using Composer and run PHPUnit:
+
+```bash
+composer install
+vendor/bin/phpunit
+```

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,14 @@
             "JVelthuis\\JVPdf\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "JVelthuis\\JVPdf\\Tests\\": "tests/"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0"
+    },
     "authors": [
         {
             "name": "Johan Velthuis",

--- a/tests/UnitConverterTest.php
+++ b/tests/UnitConverterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace JVelthuis\JVPdf\Tests;
+
+use PHPUnit\Framework\TestCase;
+use JVelthuis\JVPdf\UnitConverter;
+use JVelthuis\JVPdf\Unit;
+
+class UnitConverterTest extends TestCase
+{
+    public function testConvertUnit()
+    {
+        $this->assertEquals(10, UnitConverter::convertUnit(10, Unit::POINT));
+        $this->assertEqualsWithDelta(28.346, UnitConverter::convertUnit(10, Unit::MM), 0.001);
+        $this->assertEquals(720, UnitConverter::convertUnit(10, Unit::INCH));
+    }
+
+    public function testConvertFromPoints()
+    {
+        $this->assertEquals(10, UnitConverter::convertFromPoints(10, Unit::POINT));
+        $this->assertEqualsWithDelta(3.528, UnitConverter::convertFromPoints(10, Unit::MM), 0.001);
+        $this->assertEqualsWithDelta(0.1389, UnitConverter::convertFromPoints(10, Unit::INCH), 0.001);
+    }
+
+    public function testConvertCoordinates()
+    {
+        $pageSize = [200, 300];
+
+        $this->assertSame([10, 15], UnitConverter::convertCoordinates(10, 15, $pageSize, Unit::POINT, false));
+        $this->assertSame([10, 285], UnitConverter::convertCoordinates(10, 15, $pageSize, Unit::POINT, true));
+
+        $pageSize = [595, 842];
+        $this->assertSame([72, 770], UnitConverter::convertCoordinates(25.4, 25.4, $pageSize, Unit::MM, true));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `UnitConverter`
- configure dev autoload and PHPUnit dependency
- document running tests

## Testing
- `composer install` *(fails: composer not found)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*