### PR TITLE
Fix UnitConverter tests for coordinate precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 
 JVPDF is a wrapper around TCPDF and FPDI to create cleaner code for fairly simple PDF file generation.
 Take a look at the examples for usage.
+
+## Running Tests
+
+Install dependencies using Composer and run PHPUnit:
+
+```bash
+composer install
+vendor/bin/phpunit
+```

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,14 @@
             "JVelthuis\\JVPdf\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "JVelthuis\\JVPdf\\Tests\\": "tests/"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0"
+    },
     "authors": [
         {
             "name": "Johan Velthuis",

--- a/tests/UnitConverterTest.php
+++ b/tests/UnitConverterTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace JVelthuis\JVPdf\Tests;
+
+use PHPUnit\Framework\TestCase;
+use JVelthuis\JVPdf\UnitConverter;
+use JVelthuis\JVPdf\Unit;
+
+class UnitConverterTest extends TestCase
+{
+    public function testConvertUnit()
+    {
+        $this->assertEquals(10, UnitConverter::convertUnit(10, Unit::POINT));
+        $this->assertEqualsWithDelta(28.346, UnitConverter::convertUnit(10, Unit::MM), 0.001);
+        $this->assertEquals(720, UnitConverter::convertUnit(10, Unit::INCH));
+    }
+
+    public function testConvertFromPoints()
+    {
+        $this->assertEquals(10, UnitConverter::convertFromPoints(10, Unit::POINT));
+        $this->assertEqualsWithDelta(3.528, UnitConverter::convertFromPoints(10, Unit::MM), 0.001);
+        $this->assertEqualsWithDelta(0.1389, UnitConverter::convertFromPoints(10, Unit::INCH), 0.001);
+    }
+
+    public function testConvertCoordinates()
+    {
+        $pageSize = [200, 300];
+
+        $result = UnitConverter::convertCoordinates(10, 15, $pageSize, Unit::POINT, false);
+        $this->assertEquals([10, 15], $result);
+
+        $result = UnitConverter::convertCoordinates(10, 15, $pageSize, Unit::POINT, true);
+        $this->assertEquals([10, 285], $result);
+
+        $pageSize = [595, 842];
+        $result = UnitConverter::convertCoordinates(25.4, 25.4, $pageSize, Unit::MM, true);
+        $this->assertEqualsWithDelta(72, $result[0], 0.001);
+        $this->assertEqualsWithDelta(770, $result[1], 0.001);
+    }
+}


### PR DESCRIPTION
## Summary
- adjust `UnitConverterTest` to use `assertEquals` with delta
- verify returned coordinates with float precision

## Testing
- `composer install` *(fails: composer not found)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*