### PR TITLE
Generate example PDFs and regression test

### DIFF
--- a/generate_examples.php
+++ b/generate_examples.php
@@ -1,0 +1,24 @@
+<?php
+
+$exampleDir = __DIR__ . '/examples';
+$exampleScripts = glob($exampleDir . '/[0-9][0-9][0-9]*.php');
+
+foreach ($exampleScripts as $script) {
+	$cmd = 'php ' . escapeshellarg($script);
+	$return = null;
+	passthru($cmd, $return);
+
+	if ($return !== 0) {
+		fwrite(STDERR, "Error executing {$script}\n");
+		continue;
+	}
+
+	$targetName = preg_replace('/\.php$/', '.pdf', basename($script));
+	$outputFile = $exampleDir . '/output.pdf';
+	if (file_exists($outputFile)) {
+		rename($outputFile, $exampleDir . '/' . $targetName);
+		echo "Generated {$targetName}\n";
+	} else {
+		fwrite(STDERR, "Output file not found for {$script}\n");
+	}
+}

--- a/tests/ExamplePdfTest.php
+++ b/tests/ExamplePdfTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace JVelthuis\JVPdf\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class ExamplePdfTest extends TestCase
+{
+	public function testExamplePdfs()
+	{
+		$exampleDir = realpath(__DIR__ . '/../examples');
+		$scripts = glob($exampleDir . '/[0-9][0-9][0-9]*.php');
+
+		foreach ($scripts as $script) {
+			$expected = preg_replace('/\.php$/', '.pdf', $script);
+			$cmd = 'php ' . escapeshellarg($script);
+			exec($cmd, $output, $result);
+			$this->assertSame(0, $result, "Failed executing $script");
+
+			$generated = $exampleDir . '/output.pdf';
+			$this->assertFileExists($generated);
+
+			if (!file_exists($expected)) {
+				rename($generated, $expected);
+				$this->markTestIncomplete(basename($expected) . ' baseline created');
+				continue;
+			}
+
+			$this->assertFileEquals($expected, $generated);
+			unlink($generated);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `generate_examples.php` script to build PDFs for all example scripts
- add `ExamplePdfTest` for regression checking generated PDFs

## Testing
- `composer install` *(fails: curl error 28)*