### PR TITLE
Fix example paths and set phpunit bootstrap

### DIFF
--- a/examples/006-images.php
+++ b/examples/006-images.php
@@ -8,7 +8,7 @@ $pdf->setTitle('JV Example 1');
 
 $pdf->addPage();
 
-$fontImpact = $pdf->AddFont(__DIR__.'fonts/impact.ttf');
+$fontImpact = $pdf->AddFont(__DIR__.'/fonts/impact.ttf');
 $pdf->SetFont($fontImpact, 24);
 
 $tc = $pdf->pdf;
@@ -16,12 +16,12 @@ $tc->setXY(50,10);
 $tc->Cell(50, 10, "Example 6");
 
 $pdf->Image(__DIR__."/img/rock-pianist.jpg", 40, 50, 100);
-$pdf->Image(__DIR__."img/transparent.png", 70, 100, 50);
+$pdf->Image(__DIR__."/img/transparent.png", 70, 100, 50);
 
 
 //$tc->ImageEps(__DIR__.'/img/logo.pdf', 50, 50, 50, 50);
 $tc->ImageSVG(__DIR__.'/img/logo.svg', 50, 50, 100);
-$pdf->ImagePDF(__DIR__."img/logo.pdf", 50, 200, 75);
+$pdf->ImagePDF(__DIR__."/img/logo.pdf", 50, 200, 75);
 
 // Render the PDF to a file
 $pdf->render('output.pdf');

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="default">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- ensure images example uses proper path separators
- add `phpunit.xml` so PHPUnit loads the Composer autoloader

## Testing
- `phpunit tests` *(fails: ExamplePdfTest mismatches)*